### PR TITLE
Improve style of Settings window.

### DIFF
--- a/GyroShell/Settings/AboutPage.xaml
+++ b/GyroShell/Settings/AboutPage.xaml
@@ -8,42 +8,50 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ScrollViewer HorizontalScrollMode="Disabled">
+        <ScrollViewer HorizontalScrollMode="Disabled" HorizontalAlignment="Stretch" Margin="10">
             <StackPanel>
-                <TextBlock Text="About GyroShell" FontWeight="SemiBold" Margin="20" VerticalAlignment="Top" HorizontalAlignment="Left" FontSize="30" TextWrapping="WrapWholeWords"/>
+                <TextBlock Text="About GyroShell" Style="{StaticResource TitleTextBlockStyle}" Margin="20" VerticalAlignment="Top" HorizontalAlignment="Left" TextWrapping="WrapWholeWords"/>
                 <Expander ExpandDirection="Down" HorizontalAlignment="Stretch" Margin="20,20,20,0" VerticalAlignment="Top" HorizontalContentAlignment="Left">
                     <Expander.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="&#xE946;" FontFamily="Segoe MDL2 Assets" Margin="0,13,10,10" FontSize="16"/>
-                            <TextBlock Text="App Information" Margin="0,10,10,10" TextWrapping="WrapWholeWords"/>
+                        <StackPanel Orientation="Horizontal" Padding="5,10,5,10">
+                            <TextBlock Text="&#xE946;" FontFamily="Segoe MDL2 Assets" Margin="0,13,10,10" FontSize="24"/>
+                            <TextBlock Text="App Information" Margin="10,14,10,10" TextWrapping="WrapWholeWords"/>
                         </StackPanel>
                     </Expander.Header>
                     <Expander.Content>
-                        <StackPanel>
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                <TextBlock Text="App Version: " FontSize="15" FontWeight="Medium" TextWrapping="WrapWholeWords"/>
-                                <TextBlock Text="ERROR - Cannot parse app version." FontSize="15" Margin="5,0,0,0" x:Name="VersionText" TextWrapping="WrapWholeWords"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                <TextBlock Text="App Architecture: " FontSize="15" FontWeight="Medium" TextWrapping="WrapWholeWords"/>
-                                <TextBlock Text="ERROR - Cannot parse app architecture." FontSize="15" Margin="5,0,0,0" x:Name="ArchText" TextWrapping="WrapWholeWords"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="Build Date: " FontSize="15" FontWeight="Medium" TextWrapping="WrapWholeWords"/>
-                                <TextBlock Text="ERROR - Cannot parse app build date." FontSize="15" Margin="5,0,0,0" x:Name="BDText" TextWrapping="WrapWholeWords"/>
-                            </StackPanel>
+                        <StackPanel Padding="48,0,48,0">
+                            <Grid RowSpacing="12">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition MinWidth="130" Width="*"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+
+                                <TextBlock Grid.Row="0" Text="App Version" Style="{StaticResource BodyStrongTextBlockStyle}" TextWrapping="WrapWholeWords"/>
+                                <TextBlock Grid.Row="0" Grid.Column="1" Text="ERROR - Cannot parse app version." Style="{StaticResource BodyTextBlockStyle}" Foreground="LightGray" Margin="5,0,0,0" x:Name="VersionText" TextWrapping="WrapWholeWords"/>
+
+                                <TextBlock Grid.Row="1" Text="App Architecture" Style="{StaticResource BodyStrongTextBlockStyle}" TextWrapping="WrapWholeWords"/>
+                                <TextBlock Grid.Row="1" Grid.Column="1" Text="ERROR - Cannot parse app architecture." Style="{StaticResource BodyTextBlockStyle}" Foreground="LightGray" Margin="5,0,0,0" x:Name="ArchText" TextWrapping="WrapWholeWords"/>
+
+                                <TextBlock Grid.Row="2" Text="Build Date" Style="{StaticResource BodyStrongTextBlockStyle}" TextWrapping="WrapWholeWords"/>
+                                <TextBlock Grid.Row="2" Grid.Column="1" Text="ERROR - Cannot parse app build date." Style="{StaticResource BodyTextBlockStyle}" Foreground="LightGray" Margin="5,0,0,0" x:Name="BDText" TextWrapping="WrapWholeWords"/>
+                            </Grid>
                         </StackPanel>
                     </Expander.Content>
                 </Expander>
                 <Expander ExpandDirection="Down" HorizontalAlignment="Stretch" Margin="20,20,20,0" VerticalAlignment="Top" HorizontalContentAlignment="Left">
                     <Expander.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="&#xE71B;" FontFamily="Segoe MDL2 Assets" Margin="0,13,10,10"/>
-                            <TextBlock Text="Links" Margin="0,10,10,10" TextWrapping="WrapWholeWords"/>
+                        <StackPanel Orientation="Horizontal" Padding="5,10,5,10">
+                            <TextBlock Text="&#xE71B;" FontFamily="Segoe MDL2 Assets" Margin="0,13,10,10" FontSize="24"/>
+                            <TextBlock Text="Links" Margin="10,14,10,10" TextWrapping="WrapWholeWords"/>
                         </StackPanel>
                     </Expander.Header>
                     <Expander.Content>
-                        <StackPanel Orientation="Horizontal">
+                        <StackPanel Orientation="Horizontal" Padding="48,0,48,0">
                             <HyperlinkButton NavigateUri="https://github.com/Pdawg-bytes/GyroShell" Content="GitHub - Source Code"/>
                             <HyperlinkButton NavigateUri="https://github.com/Pdawg-bytes/GyroShell/issues/new" Content="GitHub - Report a bug"/>
                         </StackPanel>
@@ -51,13 +59,13 @@
                 </Expander>
                 <Expander ExpandDirection="Down" HorizontalAlignment="Stretch" Margin="20,20,20,0" VerticalAlignment="Top" HorizontalContentAlignment="Left">
                     <Expander.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="&#xEC08;" FontFamily="Segoe MDL2 Assets" Margin="0,12,10,10" FontSize="16"/>
-                            <TextBlock Text="Source code license" Margin="0,10,10,10" TextWrapping="WrapWholeWords"/>
+                        <StackPanel Orientation="Horizontal" Padding="5,10,5,10">
+                            <TextBlock Text="&#xEC08;" FontFamily="Segoe MDL2 Assets" Margin="0,12,10,10" FontSize="24"/>
+                            <TextBlock Text="Source code license" Margin="10,14,10,10" TextWrapping="WrapWholeWords"/>
                         </StackPanel>
                     </Expander.Header>
                     <Expander.Content>
-                        <StackPanel Orientation="Horizontal">
+                        <StackPanel Orientation="Horizontal" Padding="48,0,48,0">
                             <HyperlinkButton Content="GitHub - MIT Source License" NavigateUri="https://github.com/Pdawg-bytes/GyroShell/blob/main/LICENSE"/>
                             <HyperlinkButton Content="OSI - MIT License Information" NavigateUri="https://opensource.org/licenses/MIT"/>
                         </StackPanel>

--- a/GyroShell/Settings/Customization.xaml
+++ b/GyroShell/Settings/Customization.xaml
@@ -10,7 +10,7 @@
     <Grid>
         <ScrollViewer HorizontalScrollMode="Disabled" HorizontalAlignment="Stretch" Margin="10">
             <StackPanel>
-                <TextBlock Text="Customization" FontWeight="SemiBold" Margin="20" VerticalAlignment="Top" HorizontalAlignment="Left" FontSize="30" TextWrapping="WrapWholeWords"/>
+                <TextBlock Text="Customization" Style="{StaticResource TitleTextBlockStyle}" Margin="20" VerticalAlignment="Top" HorizontalAlignment="Left" TextWrapping="WrapWholeWords"/>
                 <ComboBox x:Name="TransparencyType" Header="Set GyroShell's bar transparency effect" Margin="20,20,0,0" SelectionChanged="TransparencyType_SelectionChanged">
                     <x:String>Mica Alt</x:String>
                     <x:String>Mica</x:String>
@@ -18,27 +18,27 @@
                 </ComboBox>
                 <Expander x:Name="ClockExpander" HorizontalAlignment="Stretch" Margin="20,20,0,0" HorizontalContentAlignment="Left">
                     <Expander.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="&#xF182;" FontFamily="Segoe MDL2 Assets" Margin="5" FontSize="16"/>
-                            <TextBlock Text="Clock Settings" Margin="5"/>
+                        <StackPanel Orientation="Horizontal" Padding="5,10,5,10">
+                            <TextBlock Text="&#xF182;" FontFamily="Segoe MDL2 Assets" Margin="0,13,10,10" FontSize="22"/>
+                            <TextBlock Text="Clock Settings" Margin="10,13,10,10"/>
                         </StackPanel>
                     </Expander.Header>
                     <Expander.Content>
-                        <StackPanel>
-                            <ToggleSwitch Header="Use seconds in time" VerticalAlignment="Top" HorizontalAlignment="Left" x:Name="SecondsToggle" Toggled="SecondsToggle_Toggled"/>
+                        <StackPanel Padding="48,0,48,0">
+                            <ToggleSwitch Header="Use seconds in time" Margin="0,0,0,8" VerticalAlignment="Top" HorizontalAlignment="Left" x:Name="SecondsToggle" Toggled="SecondsToggle_Toggled"/>
                             <ToggleSwitch Header="24 Hour time" VerticalAlignment="Top" HorizontalAlignment="Left" x:Name="TFHourToggle" Toggled="TFHourToggle_Toggled"/>
                         </StackPanel>
                     </Expander.Content>
                 </Expander>
                 <Expander x:Name="IconExpander" HorizontalAlignment="Stretch" Margin="20,20,0,0" HorizontalContentAlignment="Left">
                     <Expander.Header>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="&#xE790;" FontFamily="Segoe MDL2 Assets" Margin="3,7,7,5" FontSize="16"/>
-                            <TextBlock Text="Icon Settings" Margin="5"/>
+                        <StackPanel Orientation="Horizontal" Padding="5,10,5,10">
+                            <TextBlock Text="&#xE790;" FontFamily="Segoe MDL2 Assets" Margin="0,13,10,10" FontSize="22"/>
+                            <TextBlock Text="Icon Settings" Margin="10,13,10,10"/>
                         </StackPanel>
                     </Expander.Header>
                     <Expander.Content>
-                        <StackPanel>
+                        <StackPanel Padding="48,0,48,0">
                             <RadioButton Content="Windows 10 Icon Style" GroupName="IconStyle" Margin="0,0,0,8" x:Name="Icon10" Checked="Icon_Checked"/>
                             <RadioButton Content="Windows 11 Icon Style" GroupName="IconStyle" x:Name="Icon11" Checked="Icon_Checked"/>
                         </StackPanel>

--- a/GyroShell/Settings/SettingsWindow.xaml
+++ b/GyroShell/Settings/SettingsWindow.xaml
@@ -5,8 +5,7 @@
     xmlns:local="using:GyroShell.Settings"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    >
+    mc:Ignorable="d">
 
     <Grid>
         <Grid.RowDefinitions>
@@ -15,12 +14,12 @@
         </Grid.RowDefinitions>
         <Grid x:Name="AppTitleBar" Grid.Row="0" Background="Transparent" Opacity="1">
             <StackPanel Orientation="Horizontal">
-                <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE713;" Margin="15,12,0,0" FontSize="18"/>
-                <TextBlock Text="GyroShell Settings" Margin="15,10,0,0" FontSize="14"/>
+                <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE713;" Margin="16,15,0,0" FontSize="18"/>
+                <TextBlock Text="GyroShell Settings" Margin="16,16,0,0" Style="{StaticResource CaptionTextBlockStyle}" FontSize="12"/>
             </StackPanel>
         </Grid>
         <Grid x:Name="ContentGrid" Grid.Row="1">
-            <NavigationView x:Name="SettingNav" IsSettingsVisible="False" SelectionChanged="SettingNav_SelectionChanged">   
+            <NavigationView x:Name="SettingNav" IsSettingsVisible="False" IsBackButtonVisible="Collapsed" SelectionChanged="SettingNav_SelectionChanged">   
                 <NavigationView.MenuItems>
                     <NavigationViewItem Icon="DockBottom" Content="Bar Settings" Tag="BarSettings" />
                     <NavigationViewItem Content="Customization" Tag="Customization">


### PR DESCRIPTION
This makes the title bar look closer to the one in the Microsoft Store app.

It also makes the pages inside the settings window have expanders closer to the ones in the Settings app on Windows 11.

Screenshots:
![image](https://user-images.githubusercontent.com/51166756/215261540-0ba89e22-1403-41eb-b198-4d84a35ad86c.png)
![image](https://user-images.githubusercontent.com/51166756/215261545-e3d2d55a-a097-428d-812b-864c879cca76.png)

